### PR TITLE
Add user id as fallback for user's __repr__

### DIFF
--- a/goodreads/user.py
+++ b/goodreads/user.py
@@ -10,7 +10,10 @@ class GoodreadsUser():
         self._client = client   # for later queries
 
     def __repr__(self):
-        return self.user_name
+        if self.user_name:
+            return self.user_name
+        else:
+            return self.gid
 
     @property
     def gid(self):


### PR DESCRIPTION
Some Goodreads users don't have a username (most notably, the ones that login via Facebook).
Previously, trying to print such a user resulted in an exception as the `__repr__` method was defined to return the username.
Fall back on user ID if the username is `None`.