### PR TITLE
Handle an alternate response format returned by /review/list.

### DIFF
--- a/goodreads/review.py
+++ b/goodreads/review.py
@@ -29,9 +29,9 @@ class GoodreadsReview():
             return [shelf['@name']
                     for shelf in self._review_dict['shelves']['shelf']]
         # In some cases it appears the Goodreads API returns a response
-        # where the 'shelf' object is not a str[] but rather a single
-        # str containing the name of one shelf. In this case the Exception
-        # "TypeError: string indices must be integers" is raised.
+        # where 'shelf' object is not a list but rather a single shelf.
+        # In this case the Exception "TypeError: string indices must be
+        # integers" is raised.
         except TypeError:
             return [self._review_dict['shelves']['shelf']['@name']]
 

--- a/goodreads/review.py
+++ b/goodreads/review.py
@@ -25,8 +25,15 @@ class GoodreadsReview():
     @property
     def shelves(self):
         """Shelves for the book"""
-        return [shelf['@name']
-                for shelf in self._review_dict['shelves']['shelf']]
+        try:
+            return [shelf['@name']
+                    for shelf in self._review_dict['shelves']['shelf']]
+        # In some cases it appears the Goodreads API returns a response
+        # where the 'shelf' object is not a str[] but rather a single
+        # str containing the name of one shelf. In this case the Exception
+        # "TypeError: string indices must be integers" is raised.
+        except TypeError:
+            return [self._review_dict['shelves']['shelf']['@name']]
 
     @property
     def recommended_for(self):


### PR DESCRIPTION
Thanks for making this, incredibly useful!!

I found that the Goodreads API when listing shelves, sometimes returns a slightly different format, with one shelf instead of a list. Maybe if only one shelf exists, I'm not totally sure. I added some code to handle the alternate response format.